### PR TITLE
Upgrade to Billing Library 6.0.1

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -58,7 +58,7 @@
     <source-file src="src/android/Security.java" target-dir="app/src/main/java/com/alexdisler/inapppurchases" />
     <source-file src="src/android/IabSkuDetails.java" target-dir="app/src/main/java/com/alexdisler/inapppurchases" />
 
-    <framework src="com.android.billingclient:billing:5.0.0" />
+    <framework src="com.android.billingclient:billing:6.0.1" />
   </platform>
 
 </plugin>


### PR DESCRIPTION
It's required for Android 14. (Although 5.0.0 worked fine on my test device in a debug build. Maybe it's a restriction enforced by Google Play.) It's largely backwards-compatible. I didn't find anything in https://developer.android.com/google/play/billing/release-notes that would break this plugin. So go for it.